### PR TITLE
Fix function desugaring bug

### DIFF
--- a/ursonnet.go
+++ b/ursonnet.go
@@ -150,7 +150,10 @@ func injectTrace(a ast.Node, seen map[ast.Node]bool) error {
 			tbase.SetContext(field.Body.Context())
 			tbase.SetFreeVariables(field.Body.FreeVariables())
 			if loc := tbase.Loc(); loc != nil {
-				*loc = *field.Body.Loc()
+				// I was tempted to use field.Body.Loc() but it turns out that's not
+				// initialized in some desugarings like `f(arg): body` -> `f: function(arg) body`.
+				// OTOH, the field location itself is always available
+				*loc = field.LocRange
 			}
 			trace := ast.Apply{
 				NodeBase: tbase,


### PR DESCRIPTION
Fixes #28 

Turns out that when `f(arg):: body` desugars to `f:: function(arg) body`, the function node doesn't have its Location initialized.

When we create the `std.trace` ast node and apply it around a `field: value`, we copy the Location from the "value".
When the value is a desugared `function(arg) body` , we thus copy an empy location and that causes the crash.

This fix just  uses the "field" ast node instead of the "value" ast node. The location will generally be on the same line, and when not it's because the user has written:

```jsonnet
{
  myfunc(a)::

   a*a,
}
```

With this PR we'll report line number 2 as the line where "myfunc" is declared, which is a sensible thing to do even if it didn't also fix #28 